### PR TITLE
Add Babel configuration file

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,4 @@
+module.exports = function(api) {
+  api.cache(true);
+  return { presets: ['babel-preset-expo'] };
+};


### PR DESCRIPTION
## Summary
- add Expo preset `babel.config.js` for default Babel settings

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6865cc0f88f4832989c28b7e049bab94